### PR TITLE
WIP: add configuration for HDMI

### DIFF
--- a/main/display.c
+++ b/main/display.c
@@ -208,7 +208,19 @@ void display_quit() {
 void display_init() {
 	//initialize LCD
 	const bsp_display_config_t config = {
-		.hdmi_resolution = BSP_HDMI_RES_NONE,
+#if CONFIG_BSP_LCD_TYPE_HDMI
+#if CONFIG_BSP_LCD_HDMI_800x600_60HZ
+            .hdmi_resolution = BSP_HDMI_RES_800x600,
+#elif CONFIG_BSP_LCD_HDMI_1280x720_60HZ
+            .hdmi_resolution = BSP_HDMI_RES_1280x720,
+#elif CONFIG_BSP_LCD_HDMI_1280x800_60HZ
+            .hdmi_resolution = BSP_HDMI_RES_1280x800,
+#elif CONFIG_BSP_LCD_HDMI_1920x1080_30HZ
+            .hdmi_resolution = BSP_HDMI_RES_1920x1080,
+#endif
+#else
+            .hdmi_resolution = BSP_HDMI_RES_NONE,
+#endif
 		.dsi_bus = {
 			.phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,
 			.lane_bit_rate_mbps = BSP_LCD_MIPI_DSI_LANE_BITRATE_MBPS,

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,4 +1,4 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp32_p4_function_ev_board_noglib: "^4.1.0"
+  espressif/esp32_p4_function_ev_board_noglib: "^4.2.2"
   usb_host_hid: "^1.0.1"


### PR DESCRIPTION
Add support for HDMI.

Current changes:
- register supported HDMI resolution in ESP-BSP: https://github.com/espressif/esp-bsp/blob/731fa5ea18f07e522a41352ebf2024c90e7c9c95/bsp/esp32_p4_function_ev_board/esp32_p4_function_ev_board.c#L824C1-L836C7
- update [esp32_p4_function_eve_board_noglib](https://components.espressif.com/components/espressif/esp32_p4_function_ev_board_noglib) component


TODO:
- resolve color mapping
- keyboard seems to be crashing with new ESP-IDF 5.5, this problem was noticed also in another app
```
I (6306) example: HID Device, protocol 'KEYBOARD' CONNECTED

abort() was called at PC 0x480715d7 on core 1
--- 0x480715d7: usb_dwc_ll_hctsiz_set_sched_info at /Users/georgik/projects/esp-idf/components/hal/esp32p4/include/hal/usb_dwc_ll.h:843
 (inlined by) usb_dwc_hal_chan_set_ep_char at /Users/georgik/projects/esp-idf/components/hal/usb_dwc_hal.c:399
```